### PR TITLE
Require Git_jll v2.31 and Julia v1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1'
+          - '^1.6.0-0'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -35,7 +34,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,18 @@
 name = "GitCommand"
 uuid = "49b5b516-ca3f-4003-a081-42bdcf55082d"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
+JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Git_jll = "f8c6e375-362e-5223-8a59-34ff63f689eb"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
 
 [compat]
+JLLWrappers = "1.1"
+Git_jll = "2.31"
 ReplMaker = "0.2.3"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/GitCommand.jl
+++ b/src/GitCommand.jl
@@ -1,5 +1,6 @@
 module GitCommand
 
+import JLLWrappers
 import Git_jll
 import ReplMaker
 

--- a/src/env.jl
+++ b/src/env.jl
@@ -7,8 +7,8 @@ function _env_mapping(; adjust_PATH::Bool = true,
             if haskey(ENV, "PATH")
                 env_mapping["PATH"] = ENV["PATH"]
             end
-            if haskey(ENV, Git_jll.LIBPATH_env)
-                env_mapping[Git_jll.LIBPATH_env] = ENV[Git_jll.LIBPATH_env]
+            if haskey(ENV, JLLWrappers.LIBPATH_env)
+                env_mapping[JLLWrappers.LIBPATH_env] = ENV[JLLWrappers.LIBPATH_env]
             end
             return git_path, env_mapping
         end
@@ -28,7 +28,7 @@ function _env_mapping(; adjust_PATH::Bool = true,
         share_git_core_templates = joinpath(share_git_core, "templates")
 
         libcurlpath = dirname(Git_jll.LibCURL_jll.libcurl_path)
-        originallibpath = get(ENV, Git_jll.LIBPATH_env, "")
+        originallibpath = get(ENV, JLLWrappers.LIBPATH_env, "")
         newlibpath = "$(libcurlpath)$(sep)$(originallibpath)"
 
         ssl_cert = joinpath(dirname(Sys.BINDIR), "share", "julia", "cert.pem")
@@ -37,7 +37,7 @@ function _env_mapping(; adjust_PATH::Bool = true,
         env_mapping["GIT_EXEC_PATH"] = libexec_git_core
         env_mapping["GIT_SSL_CAINFO"] = ssl_cert
         env_mapping["GIT_TEMPLATE_DIR"] = share_git_core_templates
-        env_mapping[Git_jll.LIBPATH_env] = newlibpath
+        env_mapping[JLLWrappers.LIBPATH_env] = newlibpath
         if haskey(ENV, "PATH")
             env_mapping["PATH"] = ENV["PATH"]
         end


### PR DESCRIPTION
`Git_jll` is a complicated beast, which is compatible only with specific Julia versions because of PCRE2.

This PR requires `Git_jll` v2.31 and also Julia v1.6.  Note that `LIBPATH_env` is now defined in `JLLWrappers`

Fix #40.